### PR TITLE
Fix a crash when attempting to calculate a rotation matrix.

### DIFF
--- a/grid/lib.py
+++ b/grid/lib.py
@@ -298,7 +298,7 @@ def rotateBinNdArray(img, angle):
     imgP = np.pad(img, [sizePad, sizePad], 'constant')
 
     # rotate
-    pivot = tuple((np.array(imgP.shape[:2])/2).astype(np.int))
+    pivot = (np.array(imgP.shape[:2])/2).astype(np.int).tolist()
     matRot = cv2.getRotationMatrix2D(pivot, -angle, 1.0)
     imgR = cv2.warpAffine(
         imgP.astype(np.float32), matRot, imgP.shape, flags=cv2.INTER_LINEAR).astype(np.uint8)


### PR DESCRIPTION
This is a really simple change due to OpenCV not liking Numpy datatypes. I suspect this is some issue that cropped up in certain versions of OpenCV and/or Numpy.